### PR TITLE
Improve speed-up using multiple GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ if(CUDA_FOUND)
     list(APPEND CUDA_NVCC_FLAGS "
     --expt-extended-lambda
     --expt-relaxed-constexpr
+    --default-stream per-thread
     -arch=sm_61
      -gencode=arch=compute_50,code=sm_50
      -gencode=arch=compute_52,code=sm_52

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ For conversion and visualization of images and SOM some python scripts are avail
   - show_som.py:                    Visualize binary SOM file format
   - train.py:                       SOM training using the PINK Python interface
 
+## Benchmarks
+
+The input data for the SOM training are radio-synthesis images of Radio Galaxy Zoo containing 176750 images of the dimension 124x124.
+The SOM layout is hexagonal of the dimension 21x21 which has 331 neurons. The size of the neurons is 64x64.
+The accuracy for the rotational invariance is 1 degree and the flip invariance is used.
+
+CPU: 2x Intel Gold 5118 (12 cores in total)
+GPU: 4x NVIDIA Tesla P40
+
+|               | PINK 1.1 | Pink 2.0 |
+| ---           | ---      | ---      |
+| CPU           |          |          |
+| CPU + 1x GPU  |    3069  |     909  |
+| CPU + 2x GPU  |    2069  |     636  |
+| CPU + 4x GPU  |    1891  |     858  |
+
+
 ## Publication
 
 [Kai Lars Polsterer](https://github.com/kai-polsterer), Fabian Gieseke, Christian Igel,

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ For conversion and visualization of images and SOM some python scripts are avail
 ## Benchmarks
 
 The input data for the SOM training are radio-synthesis images of Radio Galaxy Zoo containing 176750 images of the dimension 124x124.
-The SOM layout is hexagonal of the dimension 21x21 which has 331 neurons. The size of the neurons is 64x64.
+The SOM layout is hexagonal of the dimension 21x21 which has 331 neurons (see image above). The size of the neurons is 64x64.
 The accuracy for the rotational invariance is 1 degree and the flip invariance is used.
 
 CPU: 2x Intel Gold 5118 (12 cores in total)
+
 GPU: 4x NVIDIA Tesla P40
 
 |               | PINK 1.1 | Pink 2.0 |

--- a/src/CudaLib/generate_euclidean_distance_matrix.h
+++ b/src/CudaLib/generate_euclidean_distance_matrix.h
@@ -30,11 +30,19 @@ void generate_euclidean_distance_matrix(thrust::device_vector<T>& d_euclidean_di
     DataType euclidean_distance_type)
 {
     static thrust::device_vector<T> d_first_step(som_size * number_of_spatial_transformations);
+    if (d_first_step.size() != som_size * number_of_spatial_transformations)
+    	d_first_step.resize(som_size * number_of_spatial_transformations);
 
     // First step ...
-    if (euclidean_distance_type == DataType::UINT8) {
+    if (euclidean_distance_type == DataType::UINT8)
+    {
     	static thrust::device_vector<uint8_t> d_som_uint8(d_som.size());
+    	if (d_som_uint8.size() != d_som.size())
+    		d_som_uint8.resize(d_som.size());
+
     	static thrust::device_vector<uint8_t> d_spatial_transformed_images_uint8(d_spatial_transformed_images.size());
+    	if (d_spatial_transformed_images_uint8.size() != d_spatial_transformed_images.size())
+    		d_spatial_transformed_images_uint8.resize(d_spatial_transformed_images.size());
 
         thrust::transform(d_som.begin(), d_som.end(), d_som.begin(), d_som_uint8.begin(),
             [=] __host__ __device__ (T x, [[ maybe_unused ]] T y) {

--- a/src/CudaLib/generate_euclidean_distance_matrix.h
+++ b/src/CudaLib/generate_euclidean_distance_matrix.h
@@ -29,12 +29,12 @@ void generate_euclidean_distance_matrix(thrust::device_vector<T>& d_euclidean_di
     thrust::device_vector<T> const& d_spatial_transformed_images, uint16_t block_size,
     DataType euclidean_distance_type)
 {
-    thrust::device_vector<T> d_first_step(som_size * number_of_spatial_transformations);
+    static thrust::device_vector<T> d_first_step(som_size * number_of_spatial_transformations);
 
     // First step ...
     if (euclidean_distance_type == DataType::UINT8) {
-        thrust::device_vector<uint8_t> d_som_uint8(d_som.size());
-        thrust::device_vector<uint8_t> d_spatial_transformed_images_uint8(d_spatial_transformed_images.size());
+    	static thrust::device_vector<uint8_t> d_som_uint8(d_som.size());
+    	static thrust::device_vector<uint8_t> d_spatial_transformed_images_uint8(d_spatial_transformed_images.size());
 
         thrust::transform(d_som.begin(), d_som.end(), d_som.begin(), d_som_uint8.begin(),
             [=] __host__ __device__ (T x, [[ maybe_unused ]] T y) {

--- a/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
+++ b/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
@@ -83,6 +83,8 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
                             number_of_spatial_transformations * neuron_size * sizeof(EuclideanType)));
     }
 
+    gpuErrchk(cudaDeviceSynchronize());
+
     std::vector<std::thread> workers;
     for (int i = 0; i < number_of_gpus; ++i)
     {

--- a/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
+++ b/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
@@ -31,9 +31,9 @@ std::vector<thrust::device_vector<T>> allocate_local_memory(std::vector<int> con
 	std::vector<thrust::device_vector<T>> result(sizes.size());
 
     auto&& gpu_ids = cuda_get_gpu_ids();
-    for (size_t i = 1; i < sizes.size(); ++i)
+    for (size_t i = 0; i < sizes.size(); ++i)
     {
-        cudaSetDevice(gpu_ids[i]);
+        cudaSetDevice(gpu_ids[i + 1]);
         result[i].resize(sizes[i]);
     }
     cudaSetDevice(gpu_ids[0]);

--- a/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
+++ b/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
@@ -50,6 +50,34 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
         offset[i] = offset[i-1] + size[i-1];
     }
 
+    std::vector<thrust::device_ptr<const EuclideanType>> d_som_local_ptr_list(number_of_gpus);
+    std::vector<thrust::device_ptr<const EuclideanType>> d_rotated_images_local_ptr_list(number_of_gpus);
+    std::vector<thrust::device_ptr<DataType>> d_first_step_local_ptr_list(number_of_gpus);
+
+    d_som_local_ptr_list[0] = d_som.data();
+    d_rotated_images_local_ptr_list[0] = d_rotated_images.data();
+    d_first_step_local_ptr_list[0] = d_first_step.data();
+
+    std::vector<thrust::device_vector<EuclideanType>> d_som_local(number_of_gpus - 1);
+    std::vector<thrust::device_vector<EuclideanType>> d_rotated_images_local(number_of_gpus - 1);
+    std::vector<thrust::device_vector<DataType>> d_first_step_local(number_of_gpus - 1);
+
+    for (int i = 1; i < number_of_gpus; ++i)
+    {
+        // Allocate local device memory
+        d_som_local[i-1].resize(size[i] * neuron_size);
+        d_rotated_images_local[i-1].resize(number_of_spatial_transformations * neuron_size);
+        d_first_step_local[i-1].resize(size[i] * number_of_spatial_transformations);
+
+        // Copy data
+        gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_som_local[i-1].data()), i,
+                            thrust::raw_pointer_cast(d_som.data()) + offset[i] * neuron_size, 0,
+                            size[i] * neuron_size * sizeof(EuclideanType)));
+        gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_rotated_images_local[i-1].data()), i,
+                            thrust::raw_pointer_cast(d_rotated_images.data()), 0,
+                            number_of_spatial_transformations * neuron_size * sizeof(EuclideanType)));
+    }
+
     std::vector<std::thread> workers;
     for (int i = 0; i < number_of_gpus; ++i)
     {
@@ -58,36 +86,9 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
             // Start GPU device
             cudaSetDevice(gpu_ids[i]);
 
-            thrust::device_ptr<const EuclideanType> d_som_local_ptr;
-            thrust::device_ptr<const EuclideanType> d_rotated_images_local_ptr;
-            thrust::device_ptr<DataType> d_first_step_local_ptr;
-
-            thrust::device_vector<EuclideanType> d_som_local;
-            thrust::device_vector<EuclideanType> d_rotated_images_local;
-            thrust::device_vector<DataType> d_first_step_local;
-
-            if (i != 0) {
-                // Allocate local device memory
-                d_som_local.resize(size[i] * neuron_size);
-                d_rotated_images_local.resize(number_of_spatial_transformations * neuron_size);
-                d_first_step_local.resize(size[i] * number_of_spatial_transformations);
-
-                // Copy data
-                gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_som_local.data()), i,
-                                    thrust::raw_pointer_cast(d_som.data()) + offset[i] * neuron_size, 0,
-                                    size[i] * neuron_size * sizeof(EuclideanType)));
-                gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_rotated_images_local.data()), i,
-                                    thrust::raw_pointer_cast(d_rotated_images.data()), 0,
-                                    number_of_spatial_transformations * neuron_size * sizeof(EuclideanType)));
-
-                d_som_local_ptr = d_som_local.data();
-                d_rotated_images_local_ptr = d_rotated_images_local.data();
-                d_first_step_local_ptr = d_first_step_local.data();
-            } else {
-                d_som_local_ptr = d_som.data();
-                d_rotated_images_local_ptr = d_rotated_images.data();
-                d_first_step_local_ptr = d_first_step.data();
-            }
+            auto d_som_local_ptr = d_som_local_ptr_list[i];
+            auto d_rotated_images_local_ptr = d_rotated_images_local_ptr_list[i];
+            auto d_first_step_local_ptr = d_first_step_local_ptr_list[i];
 
             // Setup execution parameters
             dim3 dim_block(block_size);
@@ -110,19 +111,22 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
                 default:
                     throw pink::exception("generate_euclidean_distance_matrix_first_step: block size not supported");
             }
+            gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
-
-            // Copy data
-            if (i != 0) {
-                gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_first_step.data()) + offset[i] * number_of_spatial_transformations, 0,
-                    thrust::raw_pointer_cast(d_first_step_local_ptr), i, size[i] * number_of_spatial_transformations * sizeof(DataType)));
-                gpuErrchk(cudaDeviceSynchronize());
-            }
         }));
     }
 
     // Wait for all workers
     for (auto&& w : workers) w.join();
+
+    for (int i = 1; i < number_of_gpus; ++i)
+    {
+        // Copy data
+		gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_first_step.data()) + offset[i] * number_of_spatial_transformations, 0,
+			thrust::raw_pointer_cast(d_first_step_local[i-1].data()), i, size[i] * number_of_spatial_transformations * sizeof(DataType)));
+	}
+
+    gpuErrchk(cudaDeviceSynchronize());
 }
 
 } // namespace pink

--- a/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
+++ b/src/CudaLib/generate_euclidean_distance_matrix_first_step_multi_gpu.h
@@ -57,8 +57,6 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
         {
             // Start GPU device
             cudaSetDevice(gpu_ids[i]);
-            cudaStream_t stream;
-            cudaStreamCreate(&stream);
 
             thrust::device_ptr<const EuclideanType> d_som_local_ptr;
             thrust::device_ptr<const EuclideanType> d_rotated_images_local_ptr;
@@ -75,12 +73,12 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
                 d_first_step_local.resize(size[i] * number_of_spatial_transformations);
 
                 // Copy data
-                gpuErrchk(cudaMemcpyPeerAsync(thrust::raw_pointer_cast(d_som_local.data()), i,
+                gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_som_local.data()), i,
                                     thrust::raw_pointer_cast(d_som.data()) + offset[i] * neuron_size, 0,
-                                    size[i] * neuron_size * sizeof(EuclideanType), stream));
-                gpuErrchk(cudaMemcpyPeerAsync(thrust::raw_pointer_cast(d_rotated_images_local.data()), i,
+                                    size[i] * neuron_size * sizeof(EuclideanType)));
+                gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_rotated_images_local.data()), i,
                                     thrust::raw_pointer_cast(d_rotated_images.data()), 0,
-                                    number_of_spatial_transformations * neuron_size * sizeof(EuclideanType), stream));
+                                    number_of_spatial_transformations * neuron_size * sizeof(EuclideanType)));
 
                 d_som_local_ptr = d_som_local.data();
                 d_rotated_images_local_ptr = d_rotated_images_local.data();
@@ -97,16 +95,16 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
 
             switch (block_size)
             {
-                case  512: euclidean_distance_kernel< 512><<<dim_grid, dim_block, 0, stream>>>(
+                case  512: euclidean_distance_kernel< 512><<<dim_grid, dim_block>>>(
                     thrust::raw_pointer_cast(d_som_local_ptr), thrust::raw_pointer_cast(d_rotated_images_local_ptr),
                     thrust::raw_pointer_cast(d_first_step_local_ptr), neuron_size); break;
-                case  256: euclidean_distance_kernel< 256><<<dim_grid, dim_block, 0, stream>>>(
+                case  256: euclidean_distance_kernel< 256><<<dim_grid, dim_block>>>(
                     thrust::raw_pointer_cast(d_som_local_ptr), thrust::raw_pointer_cast(d_rotated_images_local_ptr),
                     thrust::raw_pointer_cast(d_first_step_local_ptr), neuron_size); break;
-                case  128: euclidean_distance_kernel< 128><<<dim_grid, dim_block, 0, stream>>>(
+                case  128: euclidean_distance_kernel< 128><<<dim_grid, dim_block>>>(
                     thrust::raw_pointer_cast(d_som_local_ptr), thrust::raw_pointer_cast(d_rotated_images_local_ptr),
                     thrust::raw_pointer_cast(d_first_step_local_ptr), neuron_size); break;
-                case   64: euclidean_distance_kernel<  64><<<dim_grid, dim_block, 0, stream>>>(
+                case   64: euclidean_distance_kernel<  64><<<dim_grid, dim_block>>>(
                     thrust::raw_pointer_cast(d_som_local_ptr), thrust::raw_pointer_cast(d_rotated_images_local_ptr),
                     thrust::raw_pointer_cast(d_first_step_local_ptr), neuron_size); break;
                 default:
@@ -116,14 +114,10 @@ void generate_euclidean_distance_matrix_first_step_multi_gpu(thrust::device_vect
 
             // Copy data
             if (i != 0) {
-                gpuErrchk(cudaMemcpyPeerAsync(thrust::raw_pointer_cast(d_first_step.data()) + offset[i] * number_of_spatial_transformations, 0,
-                    thrust::raw_pointer_cast(d_first_step_local_ptr), i, size[i] * number_of_spatial_transformations * sizeof(DataType), stream));
+                gpuErrchk(cudaMemcpyPeer(thrust::raw_pointer_cast(d_first_step.data()) + offset[i] * number_of_spatial_transformations, 0,
+                    thrust::raw_pointer_cast(d_first_step_local_ptr), i, size[i] * number_of_spatial_transformations * sizeof(DataType)));
+                gpuErrchk(cudaDeviceSynchronize());
             }
-
-            gpuErrchk(cudaStreamSynchronize(stream));
-            gpuErrchk(cudaStreamDestroy(stream));
-            gpuErrchk(cudaDeviceSynchronize());
-
         }));
     }
 


### PR DESCRIPTION
Each GPU device will be controlled by a CPU thread. To allow asynchronous processes the default-stream must be set to per-thread. The device memory is set to be static to avoid costly reallocation in each update cycle.