### PR TITLE
Check for error state/clear in SOM reading

### DIFF
--- a/src/SelfOrganizingMapLib/SOM.cpp
+++ b/src/SelfOrganizingMapLib/SOM.cpp
@@ -47,6 +47,9 @@ SOM::SOM(InputData const& inputData)
             }
         }
 
+        // Check for error state
+        if (is.eof()) is.clear();
+
         // Keep header
         is.seekg(0, is.beg);
         if (binary_start_position != 0) {


### PR DESCRIPTION
The std::getline can trigger an error state when attempting to locate the end of a header by simply reading the entire file searching for the string.

Clearing the error is required before the seekg and tellg calls make sense and work as expected. Without doing so there will be readSOM errors thrown