### PR TITLE
Only scan for end of header if header implied

### DIFF
--- a/src/ImageProcessingLib/ImageIterator.h
+++ b/src/ImageProcessingLib/ImageIterator.h
@@ -40,10 +40,15 @@ public:
         // Skip all header lines starting with #
         std::string line;
         int binary_start_position = ptrStream_->tellg();
-        while (std::getline(*ptrStream_, line)) {
-            if (line == "# END OF HEADER") {
-                binary_start_position = ptrStream_->tellg();
-                break;
+
+        // only scan if header is implied
+        std::getline(*ptrStream_, line);
+        if (line[0] == '#'){
+            while (std::getline(*ptrStream_, line)) {
+                if (line == "# END OF HEADER") {
+                    binary_start_position = ptrStream_->tellg();
+                    break;
+                }
             }
         }
 

--- a/src/SelfOrganizingMapLib/SOM.cpp
+++ b/src/SelfOrganizingMapLib/SOM.cpp
@@ -40,10 +40,15 @@ SOM::SOM(InputData const& inputData)
         // Skip header
         std::string line;
         int binary_start_position = 0;
-        while (std::getline(is, line)) {
-            if (line == "# END OF HEADER") {
-                binary_start_position = is.tellg();
-                break;
+
+        // only scan if a header is implied
+        std::getline(is, line);
+        if (line[0] == '#'){
+            while (std::getline(is, line)) {
+                if (line == "# END OF HEADER") {
+                    binary_start_position = is.tellg();
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Scanning an entire file for the `# END OF HEADER` string can be very time consuming if large inputing files (i.e. image binary) are used. For small files there is nearly no delay, but for files that are 10s+GB it can take minutes to begin training/mapping. During testing a 241GB image binary would take about 10 minutes before training would commence. 

This will only scan for the end of a header if there is a header implied by the first character being a #, otherwise no scan is performed. If I understand our header definition this should be backwards compatible and only serves to avoid potential costly scans. 