### PR TITLE
Better header reader

### DIFF
--- a/src/ImageProcessingLib/ImageIterator.h
+++ b/src/ImageProcessingLib/ImageIterator.h
@@ -42,15 +42,13 @@ public:
         int binary_start_position = ptrStream_->tellg();
 
         // only scan if header is implied
-        std::getline(*ptrStream_, line);
-        if (line[0] == '#'){
-            while (std::getline(*ptrStream_, line)) {
-                if (line == "# END OF HEADER") {
-                    binary_start_position = ptrStream_->tellg();
-                    break;
-                }
+        while (std::getline(*ptrStream_, line) && line[0] == '#') {
+            if (line == "# END OF HEADER") {
+                binary_start_position = ptrStream_->tellg();
+                break;
             }
         }
+    
 
         ptrStream_->clear(); // Reset EOF flag
         ptrStream_->seekg(binary_start_position, ptrStream_->beg);

--- a/src/SelfOrganizingMapLib/SOM.cpp
+++ b/src/SelfOrganizingMapLib/SOM.cpp
@@ -42,16 +42,13 @@ SOM::SOM(InputData const& inputData)
         int binary_start_position = 0;
 
         // only scan if a header is implied
-        std::getline(is, line);
-        if (line[0] == '#'){
-            while (std::getline(is, line)) {
-                if (line == "# END OF HEADER") {
-                    binary_start_position = is.tellg();
-                    break;
-                }
+        while (std::getline(is, line) && line[0] == '#' ) {
+            if (line == "# END OF HEADER") {
+                binary_start_position = is.tellg();
+                break;
             }
         }
-
+    
         // Check for error state
         if (is.eof()) is.clear();
 


### PR DESCRIPTION
Much better structure for reading in the comment header. A better way of processing the header that should be more inline with the header standards - every line starts with a `#` until `# END OF HEADER` . 