### PR TITLE
Removed gaussian scaling in neighbour function

### DIFF
--- a/src/UtilitiesLib/DistributionFunction.h
+++ b/src/UtilitiesLib/DistributionFunction.h
@@ -13,6 +13,7 @@ namespace pink {
 //! Type for distribution function for SOM update
 enum class DistributionFunction {
     GAUSSIAN,
+    UNITYGAUSSIAN,
     MEXICANHAT
 };
 
@@ -20,6 +21,7 @@ enum class DistributionFunction {
 inline std::ostream& operator << (std::ostream& os, DistributionFunction function)
 {
     if (function == DistributionFunction::GAUSSIAN) os << "gaussian";
+    else if (function == DistributionFunction::UNITYGAUSSIAN) os << "unitygaussian";
     else if (function == DistributionFunction::MEXICANHAT) os << "mexicanhat";
     else os << "undefined";
     return os;

--- a/src/UtilitiesLib/DistributionFunctor.cpp
+++ b/src/UtilitiesLib/DistributionFunctor.cpp
@@ -28,7 +28,8 @@ GaussianFunctor::GaussianFunctor(float sigma, float damping)
 
 float GaussianFunctor::operator () (float distance) const
 {
-    return m_damping * std::exp(-0.5f * std::pow((distance/m_sigma), 2.0f));
+    return m_damping / (m_sigma * std::sqrt(2.0f * static_cast<float>(M_PI)))
+                   * std::exp(-0.5f * std::pow((distance/m_sigma), 2.0f));
 }
 
 MexicanHatFunctor::MexicanHatFunctor(float sigma, float damping)

--- a/src/UtilitiesLib/DistributionFunctor.cpp
+++ b/src/UtilitiesLib/DistributionFunctor.cpp
@@ -32,6 +32,17 @@ float GaussianFunctor::operator () (float distance) const
                    * std::exp(-0.5f * std::pow((distance/m_sigma), 2.0f));
 }
 
+UnityGaussianFunctor::UnityGaussianFunctor(float sigma, float damping)
+ : m_sigma(sigma),
+   m_damping(damping)
+{}
+
+float UnityGaussianFunctor::operator () (float distance) const
+{
+    return m_damping * std::exp(-0.5f * std::pow((distance/m_sigma), 2.0f));
+}
+
+
 MexicanHatFunctor::MexicanHatFunctor(float sigma, float damping)
  : m_sigma(sigma),
    m_damping(damping)

--- a/src/UtilitiesLib/DistributionFunctor.cpp
+++ b/src/UtilitiesLib/DistributionFunctor.cpp
@@ -28,8 +28,7 @@ GaussianFunctor::GaussianFunctor(float sigma, float damping)
 
 float GaussianFunctor::operator () (float distance) const
 {
-    return m_damping / (m_sigma * std::sqrt(2.0f * static_cast<float>(M_PI)))
-                   * std::exp(-0.5f * std::pow((distance/m_sigma), 2.0f));
+    return m_damping * std::exp(-0.5f * std::pow((distance/m_sigma), 2.0f));
 }
 
 MexicanHatFunctor::MexicanHatFunctor(float sigma, float damping)

--- a/src/UtilitiesLib/DistributionFunctor.h
+++ b/src/UtilitiesLib/DistributionFunctor.h
@@ -56,6 +56,23 @@ private:
 };
 
 /**
+ * @brief Functor for gaussian normalised to unity
+ *
+ * 1.0 * math.exp(-1.0/2.0 * (x / sigma)**2 )
+ */
+struct UnityGaussianFunctor : public DistributionFunctorBase
+{
+    UnityGaussianFunctor(float sigma, float damping);
+
+    float operator () (float distance) const;
+
+private:
+
+    float m_sigma;
+    float m_damping;
+};
+
+/**
  * @brief Functor for mexican hat.
  *
  * 2.0 / ( math.sqrt(3.0 * sigma) * math.pow(math.pi, 0.25))

--- a/src/UtilitiesLib/InputData.cpp
+++ b/src/UtilitiesLib/InputData.cpp
@@ -353,6 +353,9 @@ InputData::InputData(int argc, char **argv)
                 if (str == "GAUSSIAN") {
                     m_distribution_function = DistributionFunction::GAUSSIAN;
                 }
+                else if (str == "UNITYGAUSSIAN") {
+                    m_distribution_function = DistributionFunction::UNITYGAUSSIAN;
+                }
                 else if (str == "MEXICANHAT") {
                     m_distribution_function = DistributionFunction::MEXICANHAT;
                 }
@@ -628,6 +631,7 @@ void InputData::print_usage() const
                  "    <string> <float> <float>\n"
                  "\n"
                  "    gaussian sigma damping-factor\n"
+                 "    unitygaussian sigma damping-factor\n"
                  "    mexicanHat sigma damping-factor\n"
               << std::endl;
 }
@@ -637,6 +641,8 @@ std::function<float(float)> InputData::get_distribution_function() const
     std::function<float(float)> result;
     if (m_distribution_function == DistributionFunction::GAUSSIAN)
         result = GaussianFunctor(m_sigma, m_damping);
+    else if (m_distribution_function == DistributionFunction::UNITYGAUSSIAN)
+        result = UnityGaussianFunctor(m_sigma, m_damping);
     else if (m_distribution_function == DistributionFunction::MEXICANHAT)
         result = MexicanHatFunctor(m_sigma, m_damping);
     else


### PR DESCRIPTION
When using a Gaussian neighborhood function, the current behavior will change the peak as a function of sigma i.e. the area under the curve will be constant across different values of sigma. In practice this can have odd / undesired behavior  when scaling the magnitudes of the weighting update process. This can be negated if the learning rate term supplied also includes the appropriate inverse, but this can easily overlooked. 

I've edited the `GaussianFunctor` function to ensure the Gaussian neighborhood curve is always on a 0 -> 1 range. Attached is a small figure showing the behavior. The red set of curves are with the existing implementation, and the blue are with the updated. I've used sigmas ranging from 0.1 to 2. Code to reproduce is below. 

Any thoughts?

![Gaussian_Update](https://user-images.githubusercontent.com/10543142/75314243-265c1c00-589a-11ea-8303-da5f0a076c87.png)

```python 
import numpy as np

def gaussian(x, mu, sig, damp=1.):
    return damp / (sig * np.sqrt(2.*np.pi)) * np.exp(-0.5*((x-mu)/sig)**2.)

def gaussian_nonorm(x, mu, sig, damp=1.):
    return damp * np.exp(-0.5*((x-mu)/sig)**2.)

x = np.linspace(0, 5, 100)

fig, ax = plt.subplots(1,1)

for s in np.linspace(0.1, 2, 10):
    ls, = ax.plot(x, gaussian(x, 0, s, damp=1), 'r-')
for s in np.linspace(0.1, 2, 10):
    nls, = ax.plot(x, gaussian_nonorm(x, 0, s, damp=1), 'b--')

print(ls)
ax.legend([ls,nls], ['Current Curve', 'Updated Curve'],  loc='upper right')
```
